### PR TITLE
Add basic documentation and policies

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,15 @@
+# Privacy Policy
+
+This policy explains how the CRM Task Automation application (the "App") handles personal information.
+
+## Data Collection
+
+The App stores task and lead data within your Frappe instance. It does not transmit this data to external services.
+
+## Usage Information
+
+Basic usage metrics may be logged by Frappe for debugging or auditing purposes. These logs remain within your infrastructure unless you choose to share them.
+
+## Contact Information
+
+If you have questions about this policy, please contact the maintainers of this project.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
-## CRM Task Automation
+# CRM Task Automation
 
-CRM Task Automation is a custom Frappe app designed to dynamically manage tasks based on lead status changes
+CRM Task Automation is a custom Frappe application that automatically creates and assigns tasks when the status of a CRM Lead changes. It supports round-robin or load-balanced distribution of tasks based on configurable rules.
 
-#### License
+## Features
 
-mit
+- Define **Lead Task Config** records to map lead statuses to tasks.
+- Create tasks automatically when a lead transitions to a configured status.
+- Assign tasks to users based on territory, industry, or a **Task Assignment Rule**.
+- Supports round robin or load balancing strategies for assignment.
+
+## Installation
+
+This app is designed to be installed in a Frappe/ERPNext site using Bench:
+
+```bash
+bench get-app crm_task_automation <app_path>
+bench --site <your-site> install-app crm_task_automation
+```
+
+## License
+
+This project is released under the MIT License. See `license.txt` for details.

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,15 @@
+# Terms of Service
+
+These Terms of Service ("Terms") govern your use of the CRM Task Automation application (the "App"). By installing or using the App, you agree to these Terms.
+
+## Use of the App
+
+The App is provided for automating task creation and assignment in the Frappe framework. You may use the App in accordance with its documentation and within the scope of the MIT License. You are responsible for complying with all applicable laws when using the App.
+
+## Disclaimer
+
+The App is provided on an "AS IS" basis without warranties of any kind. The maintainers shall not be liable for any damages arising from the use of the App.
+
+## Changes to These Terms
+
+These Terms may be updated from time to time. Continued use of the App after changes indicates your acceptance of the revised Terms.


### PR DESCRIPTION
## Summary
- add Terms of Service and Privacy Policy
- update README with features and install notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_b_68480bd8e60c83239c5207666774d256